### PR TITLE
Bug 577961 - Model Spy List tab not accessible with keyboard only

### DIFF
--- a/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/tabs/ListTab.java
+++ b/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/tabs/ListTab.java
@@ -378,7 +378,7 @@ public class ListTab implements IViewEObjects {
 
 		tabItem.setImage(resourcePool.getImageUnchecked(ResourceProvider.IMG_Widgets_table_obj));
 
-		final ToolBar toolBar = new ToolBar(composite, SWT.FLAT | SWT.NO_FOCUS);
+		final ToolBar toolBar = new ToolBar(composite, SWT.FLAT);
 		toolBar.setLayoutData(new GridData(SWT.FILL, SWT.TOP, true, false, 2, 1));
 
 		{


### PR DESCRIPTION
- Fixed the mnemonics & no tab focus part on Windows(which seems to be
missed in the
original design.)

Change-Id: Ica4e7d5abb4e48f97d18304e20d24afedcea7f4b
Signed-off-by: Niraj Modi <niraj.modi@in.ibm.com>