### PR TITLE
Use verifyFreezeReport.sh from download.eclipse.org

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
 				}
 			}
 			steps {
-				sh "wget https://raw.githubusercontent.com/eclipse-platform/eclipse.platform.releng.aggregator/master/scripts/verifyFreezePeriod.sh"
+				sh "wget https://download.eclipse.org/eclipse/relengScripts/scripts/verifyFreezePeriod.sh"
 				sh "chmod +x verifyFreezePeriod.sh"
 				withCredentials([string(credentialsId: 'google-api-key', variable: 'GOOGLE_API_KEY')]) {
 					sh './verifyFreezePeriod.sh'


### PR DESCRIPTION
To prevent hiting raw.githubusercontent.com quota.