### PR TITLE
Bug 579683 - IES423: The 1st character of each topic is truncated in

### DIFF
--- a/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/ModelEditor.java
+++ b/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/ModelEditor.java
@@ -1063,10 +1063,10 @@ public class ModelEditor implements IGotoObject {
 		}
 		final TreeViewer viewer = tempViewer;
 
-		final FontDescriptor italicFontDescriptor = FontDescriptor.createFrom(viewer.getControl().getFont())
-				.setStyle(SWT.ITALIC);
+		final FontDescriptor fontDescriptor = FontDescriptor.createFrom(viewer.getControl().getFont())
+				.setStyle(SWT.NORMAL);
 		viewer.setLabelProvider(new DelegatingStyledCellLabelProvider(
-				new ComponentLabelProvider(this, messages, italicFontDescriptor)));
+				new ComponentLabelProvider(this, messages, fontDescriptor)));
 		final ObservableListTreeContentProvider<Object> contentProvider = new ObservableListTreeContentProvider<>(
 				new ObservableFactoryImpl(), new TreeStructureAdvisor<>() {
 				});


### PR DESCRIPTION
navigation tree of 'Model Spy' in Arabic
- Change 'Italic' font to 'Normal'

Change-Id: I329df6fbb33ff182950c94cb99c09ff9d18b32b9
Signed-off-by: Niraj Modi <niraj.modi@in.ibm.com>