### PR TITLE
Add getLineSeparator to ContributionDataFile

### DIFF
--- a/bundles/org.eclipse.e4.tools.emf.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.tools.emf.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.e4.tools.emf.ui;singleton:=true
-Bundle-Version: 4.7.300.qualifier
+Bundle-Version: 4.7.400.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
@@ -17,7 +17,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.9.0",
  org.eclipse.emf.edit;bundle-version="2.6.0",
  org.eclipse.equinox.common;bundle-version="3.6.0",
  org.eclipse.emf.databinding.edit;bundle-version="1.2.0",
- org.eclipse.core.resources;bundle-version="3.6.0",
+ org.eclipse.core.resources;bundle-version="3.18.0",
  org.eclipse.e4.core.services;bundle-version="0.9.1",
  org.eclipse.osgi;bundle-version="3.6.0",
  org.eclipse.e4.ui.css.swt.theme;bundle-version="0.9.0",

--- a/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/dialogs/ContributionDataFile.java
+++ b/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/component/dialogs/ContributionDataFile.java
@@ -703,4 +703,10 @@ public class ContributionDataFile implements IFile {
 		// TODO Auto-generated method stub
 		return null;
 	}
+
+	@Override
+	public String getLineSeparator(boolean checkParent) throws CoreException {
+		// TODO Auto-generated method stub
+		return null;
+	}
 }


### PR DESCRIPTION
IFile has introduced method getLineSeparator. The ContributionDataFile
implementation needs to declare an implementation for it.