### PR TITLE
JavaAttribute.getAttributes() should catch InaccessibleObjectException

### DIFF
--- a/bundles/org.eclipse.e4.tools.emf.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.tools.emf.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.e4.tools.emf.ui;singleton:=true
-Bundle-Version: 4.7.300.qualifier
+Bundle-Version: 4.7.400.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.e4.tools.emf.ui/pom.xml
+++ b/bundles/org.eclipse.e4.tools.emf.ui/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>eclipse.platform.ui.tools</groupId>
   <artifactId>org.eclipse.e4.tools.emf.ui</artifactId>
-  <version>4.7.300-SNAPSHOT</version>
+  <version>4.7.400-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/objectdata/JavaAttribute.java
+++ b/bundles/org.eclipse.e4.tools.emf.ui/src/org/eclipse/e4/tools/emf/ui/internal/common/objectdata/JavaAttribute.java
@@ -1,6 +1,7 @@
 package org.eclipse.e4.tools.emf.ui.internal.common.objectdata;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InaccessibleObjectException;
 import java.lang.reflect.Modifier;
 import java.util.Collections;
 import java.util.List;
@@ -61,10 +62,7 @@ public class JavaAttribute {
 			}
 			return new JavaObject(field.get(object.getInstance())).getAttributes();
 
-		} catch (final IllegalArgumentException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		} catch (final IllegalAccessException e) {
+		} catch (final IllegalArgumentException | IllegalAccessException | InaccessibleObjectException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}


### PR DESCRIPTION
It should handle this the same way as IllegalArgumentException and IllegalAccessException.

https://github.com/eclipse-platform/eclipse.platform.ui/pull/257